### PR TITLE
adjustTimelineTiming

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,7 +14,7 @@ import SlideContact from './components/SlideContact';
 class App extends Component {
   // STATE & PROPERTIES OF COMPONENT
   state = {
-    loadingStat: 0,
+    loadProgress: 0,
     currentSlideNum: 1,
     statBarActive: false,
     timelineActive: false
@@ -27,7 +27,7 @@ class App extends Component {
     smoothscroll.polyfill(); // - smoothscroll.polyfill() for handleHashClick().
   }
   componentWillUpdate() {
-    // console.log('componentWillUpdate!'); // - Check if setState() isn't being rapid-fired.
+    console.log('componentWillUpdate!'); // - Check if setState() isn't being rapid-fired.
   }
   componentDidUpdate() {
     // console.log('componentDidUpdate!');
@@ -38,18 +38,18 @@ class App extends Component {
     return (
       <main id="app" onWheel={this.handleWheel} onScroll={this.handleScroll}>
         <StatBarLoading
-          loadingStat={this.state.loadingStat}
+          loadProgress={this.state.loadProgress}
           statBarActive={this.state.statBarActive}/>
         <StatBar/>
         <Timeline
-          loadingStat={this.state.loadingStat}
+          loadProgress={this.state.loadProgress}
           timelineActive={this.state.timelineActive}
           checkSlideAttributes={this.checkSlideAttributes}
           checkActiveStatus={this.checkActiveStatus}/>
         <SlideLanding slideNum="1"/>
-        <SlideIntro slideNum="2" loadingStat="1/3"/>
-        <SlideIntro slideNum="3" loadingStat="2/3"/>
-        <SlideText slideNum="4" loadingStat="3/3"/>
+        <SlideIntro slideNum="2" loadingStatus="1/3"/>
+        <SlideIntro slideNum="3" loadingStatus="2/3"/>
+        <SlideText slideNum="4" loadingStatus="3/3"/>
         <SlideJourney slideNum="5"/>
         <SlideJourney slideNum="6"/>
         <SlideJourney slideNum="7"/>
@@ -100,8 +100,6 @@ class App extends Component {
       if (scrollCycle > width) {
         direction ? e.scrollLeft = scrollRightPx : e.scrollLeft = scrollLeftPx;
         clearInterval(scroll);
-        this.checkSlideAttributes();
-        this.checkActiveStatus();
         scrollCycle = 0;
         return;
       }
@@ -117,44 +115,47 @@ class App extends Component {
     // console.log('checkSlideAttributes');
     const app = document.querySelector('#app');
     let sHasLoadAttr;
-    let loadingStat;
+    let loadingStatus;
     let slideNum = 0;
     app.childNodes.forEach((slide) => {
       const sInView = slide.getBoundingClientRect().x === 0;
-      const sHasLoading = slide.attributes['data-loadingstat'];
+      const sHasLoading = slide.attributes['data-loadingstatus'];
       const sHasNumRegex = /[s]\d+/;
       const sHasNum = slide.id.match(sHasNumRegex);
       if (sInView && sHasNum) slideNum = +sHasNum[0].slice(1,sHasNum[0].length);
       if (sInView && sHasLoading) sHasLoadAttr = slide;
       if (sHasLoadAttr) {
-        const numerator = sHasLoadAttr.dataset.loadingstat[0];
-        const denominator = sHasLoadAttr.dataset.loadingstat[2];
-        loadingStat = numerator / denominator;
+        const numerator = sHasLoadAttr.dataset.loadingstatus[0];
+        const denominator = sHasLoadAttr.dataset.loadingstatus[2];
+        loadingStatus = numerator / denominator;
       } else {
-        loadingStat = 0;
+        loadingStatus = 0;
       }
     });
     this.setState({
-      loadingStat: loadingStat,
+      loadProgress: loadingStatus,
       currentSlideNum: slideNum
     });
   };
 
   // FUNCTION TO CHECK IF ACTIVE CLASS NEEDS TO BE ADDED TO STATBAR & TIMELINE.
-  // - If state.loadingState is 1, it will keep active class on.
+  // - If state.loadingStatuse is 1, it will keep active class on.
   checkActiveStatus = () => {
     // console.log('checkActiveStatus');
-    const statBarSlides = [5,6,7,8,9,10];
-    const statBarActive = statBarSlides.find(integer => integer === this.state.currentSlideNum);
+    const sBarSlides = [5,6,7,8,9,10];
+    const sBarActive = sBarSlides.find(integer => integer === this.state.currentSlideNum);
     const timelineSlides = [5,6,7,8,9,10,11,12];
-    const timelineActive = timelineSlides.find(integer => integer === this.state.currentSlideNum);
-    statBarActive ? this.setState({ statBarActive: true }) : this.setState({ statBarActive: false });
-    timelineActive ? this.setState({ timelineActive: true }) : this.setState({ timelineActive: false });
+    const tActive = timelineSlides.find(integer => integer === this.state.currentSlideNum);
+    sBarActive ? this.setState({ statBarActive: true }) : this.setState({ statBarActive: false });
+    tActive ? this.setState({ timelineActive: true }) : this.setState({ timelineActive: false });
   };
 
-  handleScroll = () => {
-    console.log('handleScroll');
-  }
+  // FUNCTION THAT RUNS FUNCTIONS AFTER THE SCROLL IS COMPLETE.
+  // - Implemented like this to cater for smoothScroll where the duration has variation.
+  handleScroll = debounce(() => {
+    this.checkSlideAttributes();
+    this.checkActiveStatus();
+  }, 250);
 }
 
 export default App;

--- a/src/components/SlideIntro.js
+++ b/src/components/SlideIntro.js
@@ -9,7 +9,7 @@ class SlideIntro extends Component {
         id={`s${this.props.slideNum}`}
         className="slideIntro"
         data-slidenum={this.props.slideNum}
-        data-loadingstat={this.props.loadingStat}>
+        data-loadingstatus={this.props.loadingStatus}>
         <p>SlideIntro</p>
       </section>
     );

--- a/src/components/SlideText.js
+++ b/src/components/SlideText.js
@@ -9,7 +9,7 @@ class SlideText extends Component {
         id={`s${this.props.slideNum}`}
         className="slideText"
         data-slidenum={this.props.slideNum}
-        data-loadingstat={this.props.loadingStat}>
+        data-loadingstatus={this.props.loadingStatus}>
         <p>SlideText</p>
       </section>
     );

--- a/src/components/StatBarLoading.js
+++ b/src/components/StatBarLoading.js
@@ -5,11 +5,11 @@ class LoadingStatBar extends Component {
   // RENDER OF COMPONENT
   render() {
     const isActive = this.props.statBarActive;
-    const scaleValue = isActive ? 1 : this.props.loadingStat;
+    const loadProgress = isActive ? 1 : this.props.loadProgress;
     return (
       <div
         id="loadingStatBar"
-        style={{ transform:`scaleX(${scaleValue})` }}>
+        style={{ transform:`scaleX(${loadProgress})` }}>
       </div>
     );
   }

--- a/src/components/Timeline.js
+++ b/src/components/Timeline.js
@@ -5,11 +5,11 @@ class Timeline extends Component {
   // RENDER OF COMPONENT
   render() {
     const isActive = this.props.timelineActive;
-    const loadingStat = this.props.loadingStat;
+    const loadProgress = this.props.loadProgress;
     const classValue = isActive ? 'active' : '';
     return (
       <div id="timeline" className={ classValue }>
-        <ul className="timePeriod" style={{ transform:`scaleX(${this.props.loadingProgress})` }}>
+        <ul className="timePeriod">
           <li>2008</li>
           <li></li>
           <li></li>
@@ -23,7 +23,7 @@ class Timeline extends Component {
           <li></li>
           <li></li>
           <li>2009</li>
-          <TimelineLoading loadingStat={loadingStat} timelineActive={isActive}/>
+          <TimelineLoading loadProgress={loadProgress} timelineActive={isActive}/>
         </ul>
         <ul className="timeLinks">
           <a href="#s1" onClick={this.handleHashClick}>
@@ -60,17 +60,7 @@ class Timeline extends Component {
   handleHashClick = (e) => {
     e.preventDefault();
     const target = document.querySelector(e.currentTarget.attributes.href.value);
-    const scrollIntoView = () => {
-      target.scrollIntoView({ behavior:'smooth' });
-      console.log('001');
-      return true;
-    }
-    scrollIntoView();
-    // console.log('002');
-    // setTimeout(() => {
-    //   this.props.checkSlideAttributes();
-    //   this.props.updateActiveStatus();
-    // }, 2500);
+    target.scrollIntoView({ behavior:'smooth' });
   };
 }
 

--- a/src/components/TimelineLoading.js
+++ b/src/components/TimelineLoading.js
@@ -5,11 +5,11 @@ class LoadingTimeline extends Component {
   // RENDER OF COMPONENT
   render() {
     const isActive = this.props.timelineActive;
-    const scaleValue = isActive ? 1 : this.props.loadingStat;
+    const loadProgress = isActive ? 1 : this.props.loadProgress;
     return (
       <div
         id="loadingTimeline"
-        style={{ transform:`scaleX(${scaleValue})` }}>
+        style={{ transform:`scaleX(${loadProgress})` }}>
       </div>
     );
   }


### PR DESCRIPTION
- setState() functions will now run after the scroll is complete.
- The caters for both wheel/trackpad-scroll and smoothScroll.
- smoothScroll had a duration-variation which is why this was implemented.
  - smoothScroll between 1-2 is short, 1-10 is long.
  - setState() needed to be updated based on the location.
- NEXT: StatBar Component