### PR TITLE
pressKeyForNext

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -33,11 +33,13 @@ class App extends Component {
   componentWillMount() {
     smoothscroll.polyfill(); // - smoothscroll.polyfill() for handleHashClick().
   }
+  componentDidMount() {
+    window.addEventListener('keydown', this.handleKeyDown);
+  }
   componentWillUpdate() {
     // console.log('componentWillUpdate!'); // - Check if setState() isn't being rapid-fired.
   }
   componentDidUpdate() {
-    // console.log('componentDidUpdate!');
     this.statBarPadding();
   }
 
@@ -46,6 +48,7 @@ class App extends Component {
     return (
       <main
         id="app"
+        tabIndex="0"
         onWheel={this.handleWheel}
         onScroll={this.handleScroll}>
         <StatBarLoading
@@ -245,6 +248,26 @@ class App extends Component {
     } else {
       slides.forEach(slide => slide.style.paddingTop = 0);
     }
+  };
+
+  // FUNCTION TO MOVE SLIDE BY PRESSING ARROW KEY
+  // - This is bound to window.eventListener and will not work while an input/textarea is focused.
+  handleKeyDown = (e) => {
+    // console.log('handleKeyDown');
+    const app = document.querySelector('#app');
+    const tagName = document.activeElement.tagName;
+    const inputIsActive = (tagName === "INPUT") || (tagName === "TEXTAREA");
+    const key = e.keyCode || e.which || e.key;
+    let scrollDirection;
+    if ((key === 37 && !inputIsActive) || (key === 'ArrowLeft' && !inputIsActive)) {
+      scrollDirection = false;
+    } else if ((key === 39 && !inputIsActive) || (key === 'ArrowRight' && !inputIsActive)) {
+      scrollDirection = true;
+    } else {
+      return;
+    };
+    e.preventDefault();
+    this.scrollAnimate(app, scrollDirection);
   };
 
 }

--- a/src/components/SlideLanding.js
+++ b/src/components/SlideLanding.js
@@ -24,6 +24,16 @@ class SlideLanding extends Component {
               <p>swipe</p>
             </div>
           </div>
+          <p>&emsp;or&emsp;</p>
+          <div className="navIconWrapper">
+            <p className="arrowKey">
+              <i className="far fa-caret-square-left"></i>
+            </p>
+            &ensp;
+            <p className="arrowKey">
+              <i className="far fa-caret-square-right"></i>
+            </p>
+          </div>
         </div>
       </section>
     );

--- a/src/css/_slideLanding.scss
+++ b/src/css/_slideLanding.scss
@@ -1,17 +1,30 @@
 @keyframes scroll {
   0% {transform: translateY(-100%);}
-  // 85% {transform: translateY(15%);}
   100% {transform: translateY(0%);}
 }
-
 @keyframes swipe {
-  0% {transform: translateX(0%);}
-  // 85% {transform: translateX(calc(-115% - 0.25em));}
+  0% {transform: translateX(0);}
   100% {transform: translateX(calc(-100% - 0.25em));}
+}
+@keyframes arrowKey {
+  0% {transform: translateY(0);}
+  40% {transform: translateY(0);}
+  60% {transform: translateY(2px);}
+  80% {transform: translateY(0);}
+  100% {transform: translateY(0);}
 }
 
 .slideLanding {
   flex-direction: column;
+  .navIconWrapper {
+    display: flex;
+    .arrowKey {
+      animation: 1.2s infinite ease-in-out arrowKey;
+      &:nth-child(2) {
+        animation-delay: 0.6s;
+      }
+    }
+  }
   .navTextWrapper {
     display: flex;
     flex: 0 0 auto;
@@ -43,5 +56,3 @@
     }
   }
 }
-
-

--- a/src/css/stylesheet.css
+++ b/src/css/stylesheet.css
@@ -652,12 +652,30 @@ a {
 
 @keyframes swipe {
   0% {
-    transform: translateX(0%); }
+    transform: translateX(0); }
   100% {
     transform: translateX(calc(-100% - 0.25em)); } }
 
+@keyframes arrowKey {
+  0% {
+    transform: translateY(0); }
+  40% {
+    transform: translateY(0); }
+  60% {
+    transform: translateY(2px); }
+  80% {
+    transform: translateY(0); }
+  100% {
+    transform: translateY(0); } }
+
 .slideLanding {
   flex-direction: column; }
+  .slideLanding .navIconWrapper {
+    display: flex; }
+    .slideLanding .navIconWrapper .arrowKey {
+      animation: 1.2s infinite ease-in-out arrowKey; }
+      .slideLanding .navIconWrapper .arrowKey:nth-child(2) {
+        animation-delay: 0.6s; }
   .slideLanding .navTextWrapper {
     display: flex;
     flex: 0 0 auto;


### PR DESCRIPTION
- pressKeyForNext COMPLETE
- Now pressing arrow key will also move the slide.
- This will be disabled if an 'input' or 'textarea' is active.
- Added arrow image to landing page.
- NEXT: Add active class to timeline navbar